### PR TITLE
Fix the nix-shell example

### DIFF
--- a/docs/user-guide/development.md
+++ b/docs/user-guide/development.md
@@ -34,7 +34,7 @@ included.
 ```nix
 # shell.nix
 let
-  hsPkgs = import ./default.nix {};
+  hsPkgs = import ./default.nix;
 in
   hsPkgs.my-package.components.all
 ```


### PR DESCRIPTION
the `./default.nix` provided as an example in steps before doesn't accept the parameters - its just a set.