### PR TITLE
Fixing the example ./default.nix

### DIFF
--- a/docs/user-guide/stack-projects.md
+++ b/docs/user-guide/stack-projects.md
@@ -48,7 +48,7 @@ let
   # Instantiate a package set using the generated file.
   pkgSet = haskell.mkStackPkgSet {
     stack-pkgs = import ./pkgs.nix;
-    pkg-def-overlays = [];
+    pkg-def-extras = [];
     modules = [];
   };
 in


### PR DESCRIPTION
The mkStackPkgSet accepts `pkg-def-extras` param now